### PR TITLE
devスクリプトに--host 0.0.0.0オプションを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Webサイト作成の練習",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite --host 0.0.0.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## 概要

devcontainer環境で `npm run dev` を実行した際、ホスト上のブラウザから開発サーバーにアクセスできない問題を修正します。
Viteの開発サーバーがデフォルトで `localhost` にバインドされるため、`--host 0.0.0.0` を指定して全インターフェースでリッスンするようにします。

## 関連Issue

Fixes: #7

## 修正内容

- `package.json` の `dev` スクリプトに `--host 0.0.0.0` オプションを追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 開発サーバーの設定を更新し、すべてのネットワークインターフェース上でリッスンするように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->