### PR TITLE
見本Webページとのスクリーンショット差分比較スクリプトの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Playwright
+test-results/
+playwright-report/
+
 # notify file
 host-notifier.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ vite.config.ts.timestamp-*
 # Playwright
 test-results/
 playwright-report/
+*-snapshots/
 
 # notify file
 host-notifier.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # web-practice
 Webサイト作成の練習
+
+## スクリーンショット差分比較
+
+見本WebページとVite開発サーバー上のページをスクリーンショットで比較し、差分を確認できます。
+
+### 前提条件
+
+```bash
+npm install
+npx playwright install --with-deps chromium
+```
+
+### 使い方
+
+```bash
+bash scripts/compare-screenshots.sh <見本URL> <Viteパス> [差分閾値]
+```
+
+#### 引数
+
+| 引数 | 必須 | 説明 |
+|---|---|---|
+| 見本URL | はい | 見本WebページのURL |
+| Viteパス | はい | Vite開発サーバー上のパス（例: `/about`） |
+| 差分閾値 | いいえ | 差分の許容閾値（0〜1、例: `0.05` = 5%）。省略時はPlaywrightの標準値を使用 |
+
+#### 実行例
+
+```bash
+# 基本的な使い方
+bash scripts/compare-screenshots.sh https://example.com /
+
+# 差分閾値を指定（5%まで許容）
+bash scripts/compare-screenshots.sh https://example.com /about 0.05
+```
+
+#### 比較ビューポート
+
+以下の3サイズで比較を行います:
+
+- デスクトップ（1280x720）
+- タブレット（768x1024）
+- モバイル（375x667）
+
+#### 差分画像の出力
+
+差分がある場合、`test-results/` ディレクトリに差分画像が出力されます。

--- a/e2e/screenshot-diff.spec.js
+++ b/e2e/screenshot-diff.spec.js
@@ -4,9 +4,19 @@ import { dirname } from "node:path";
 
 const referenceUrl = process.env.REFERENCE_URL;
 const devPath = process.env.DEV_PATH;
-const threshold = process.env.DIFF_THRESHOLD
-  ? parseFloat(process.env.DIFF_THRESHOLD)
-  : undefined;
+let threshold;
+
+if (!referenceUrl || !devPath) {
+  throw new Error("REFERENCE_URL と DEV_PATH は必須です");
+}
+
+if (process.env.DIFF_THRESHOLD) {
+  const parsed = Number(process.env.DIFF_THRESHOLD);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error("DIFF_THRESHOLD は0〜1の数値で指定してください");
+  }
+  threshold = parsed;
+}
 
 test("見本ページとの比較", async ({ page }, testInfo) => {
   const snapshotName = "reference.png";

--- a/e2e/screenshot-diff.spec.js
+++ b/e2e/screenshot-diff.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const referenceUrl = process.env.REFERENCE_URL;
+const devPath = process.env.DEV_PATH;
+const threshold = process.env.DIFF_THRESHOLD
+  ? parseFloat(process.env.DIFF_THRESHOLD)
+  : undefined;
+
+test("見本ページとの比較", async ({ page }, testInfo) => {
+  const snapshotName = "reference.png";
+
+  // 見本ページのスクリーンショットを取得
+  await page.goto(referenceUrl);
+  await page.waitForLoadState("networkidle");
+  const referenceScreenshot = await page.screenshot({ fullPage: true });
+
+  // スナップショットディレクトリに保存
+  const snapshotPath = testInfo.snapshotPath(snapshotName);
+  mkdirSync(dirname(snapshotPath), { recursive: true });
+  writeFileSync(snapshotPath, referenceScreenshot);
+
+  // Vite開発サーバーのページと比較
+  await page.goto(`http://localhost:5173${devPath}`);
+  await page.waitForLoadState("networkidle");
+
+  const options = {
+    fullPage: true,
+    animations: "disabled",
+  };
+  if (threshold !== undefined) {
+    options.maxDiffPixelRatio = threshold;
+  }
+
+  await expect(page).toHaveScreenshot(snapshotName, options);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "vite": "^7.3.1"
       }
     },
@@ -450,6 +451,22 @@
       "os": [
         "win32"
       ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -923,6 +940,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "vite": "^7.3.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  expect: {
+    toHaveScreenshot: {
+      animations: "disabled",
+    },
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: { viewport: { width: 1280, height: 720 } },
+    },
+    {
+      name: "tablet",
+      use: { viewport: { width: 768, height: 1024 } },
+    },
+    {
+      name: "mobile",
+      use: { viewport: { width: 375, height: 667 } },
+    },
+  ],
+});

--- a/scripts/compare-screenshots.sh
+++ b/scripts/compare-screenshots.sh
@@ -19,11 +19,19 @@ REFERENCE_URL="$1"
 DEV_PATH="$2"
 DIFF_THRESHOLD="${3:-}"
 
+if [ -n "$DIFF_THRESHOLD" ]; then
+  if ! [[ "$DIFF_THRESHOLD" =~ ^(0(\.[0-9]+)?|1(\.0+)?)$ ]]; then
+    echo "エラー: 差分閾値は0〜1の数値で指定してください" >&2
+    exit 1
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_DIR"
 
 VITE_PID=""
+VITE_PORT=5173
 
 cleanup() {
   if [ -n "$VITE_PID" ]; then
@@ -37,13 +45,13 @@ trap cleanup EXIT
 
 # Vite開発サーバーを起動
 echo "Vite開発サーバーを起動します..."
-npx vite --host 0.0.0.0 &
+npx vite --host 0.0.0.0 --port "$VITE_PORT" --strictPort &
 VITE_PID=$!
 
 # サーバー起動待機
 echo "Vite開発サーバーの起動を待機中..."
 for i in $(seq 1 30); do
-  if curl -s http://localhost:5173 > /dev/null 2>&1; then
+  if curl -s "http://localhost:${VITE_PORT}" > /dev/null 2>&1; then
     echo "Vite開発サーバーが起動しました"
     break
   fi

--- a/scripts/compare-screenshots.sh
+++ b/scripts/compare-screenshots.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "使い方: $0 <見本URL> <Viteパス> [差分閾値]"
+  echo ""
+  echo "引数:"
+  echo "  見本URL     見本WebページのURL"
+  echo "  Viteパス    Vite開発サーバー上のパス（例: /about）"
+  echo "  差分閾値    差分の許容閾値（0〜1、例: 0.05）（省略可）"
+  exit 1
+}
+
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+REFERENCE_URL="$1"
+DEV_PATH="$2"
+DIFF_THRESHOLD="${3:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+VITE_PID=""
+
+cleanup() {
+  if [ -n "$VITE_PID" ]; then
+    echo "Vite開発サーバーを終了します..."
+    kill "$VITE_PID" 2>/dev/null || true
+    wait "$VITE_PID" 2>/dev/null || true
+    echo "Vite開発サーバーを終了しました"
+  fi
+}
+trap cleanup EXIT
+
+# Vite開発サーバーを起動
+echo "Vite開発サーバーを起動します..."
+npx vite --host 0.0.0.0 &
+VITE_PID=$!
+
+# サーバー起動待機
+echo "Vite開発サーバーの起動を待機中..."
+for i in $(seq 1 30); do
+  if curl -s http://localhost:5173 > /dev/null 2>&1; then
+    echo "Vite開発サーバーが起動しました"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "エラー: Vite開発サーバーの起動がタイムアウトしました" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# Playwrightテスト実行
+echo "スクリーンショット比較を開始します..."
+REFERENCE_URL="$REFERENCE_URL" \
+DEV_PATH="$DEV_PATH" \
+DIFF_THRESHOLD="$DIFF_THRESHOLD" \
+  npx playwright test
+
+echo "スクリーンショット比較が完了しました"


### PR DESCRIPTION
## 概要
見本となるWebページと、Vite開発サーバー上のページをスクリーンショットで比較し、差分を確認するシェルスクリプトを追加します。

Fixes: #9

## 修正内容
- Playwrightを devDependencies に追加
- `playwright.config.js`: デスクトップ（1280x720）、タブレット（768x1024）、モバイル（375x667）の3ビューポートを設定
- `e2e/screenshot-diff.spec.js`: 見本ページのスクリーンショット取得・保存とVite開発サーバーページとの比較テスト
- `scripts/compare-screenshots.sh`: Vite開発サーバーの自動起動/終了を含む実行スクリプト（引数: 見本URL、Viteパス、差分閾値）
- `.gitignore`: Playwright関連ディレクトリ（test-results/, playwright-report/, *-snapshots/）を追加
- `README.md`: スクリプトの使い方を追記

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * スクリーンショット比較による視覚的回帰テストを追加しました（ローカルサーバー起動と差分検出を含む）。

* **Tests**
  * エンドツーエンドのスクリーンショット比較テストを導入しました（閾値設定とマルチビュー対応）。

* **Documentation**
  * スクリーンショット差分機能の使い方、引数、例、出力についてのドキュメントを追加しました。

* **Chores**
  * テスト実行に必要な設定と依存を追加し、テスト成果物を無視する設定を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->